### PR TITLE
feat: add confirm button if number + string input

### DIFF
--- a/web/src/components/ParamPicker.tsx
+++ b/web/src/components/ParamPicker.tsx
@@ -14,6 +14,7 @@ type ParamDefinition = {
 
 type PropsType = {
   value: Record<string, any>,
+  setAdditionalParams: (newValue: Record<string, any>) => void,
   onChange: (newValue: Record<string, any>) => void,
   params: ParamDefinition[],
   onSubmit?: () => void,
@@ -45,8 +46,9 @@ const EnumPicker: React.FC<EnumPickerPropsType> = ( { label, value, variants, on
   )
 }
 
-const ParamPicker: React.FC<PropsType> = ({ value, onChange, params, onSubmit, open, onOpenChange }) => {
+const ParamPicker: React.FC<PropsType> = ({ value, setAdditionalParams, onChange, params, onSubmit, open, onOpenChange }) => {
   const hasOnSubmit = !!onSubmit
+  let needConfirm = false;
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={'p-md'}>
@@ -65,29 +67,37 @@ const ParamPicker: React.FC<PropsType> = ({ value, onChange, params, onSubmit, o
                   />
                 );
               case 'number':
+                needConfirm = true;
                 return (
-                  <Input
-                    key={param.name}
-                    type={'number'}
-                    placeholder={param.name}
-                    value={value[param.name]}
-                    onChange={(e) => onChange({...value, [param.name]: Number(e.target.value)})}
-                  />
+                    <Input
+                      key={`${param.name}-input`}
+                      type={'number'}
+                      placeholder={param.name}
+                      value={value[param.name]}
+                      className='mb-3'
+                      onChange={(e) => setAdditionalParams({...value, [param.name]: Number(e.target.value)})}
+                    />
                 );
               case 'string':
+                needConfirm = true;
                 return (
-                  <Input
-                    key={param.name}
-                    type={'text'}
-                    placeholder={param.name}
-                    value={value[param.name]}
-                    onChange={(e) => onChange({...value, [param.name]: e.target.value})}
-                  />
+                    <Input
+                      key={`${param.name}-input`}
+                      type={'text'}
+                      placeholder={param.name}
+                      value={value[param.name]}
+                      className='mr-2'
+                      onChange={(e) => setAdditionalParams({...value, [param.name]: Number(e.target.value)})}
+                    />
                 );
               default:
                 return null;
             }
           })}
+        {needConfirm && <Button 
+          className={"w-[50%]"} onClick={() => onChange(value)}>
+          Confirm
+        </Button>}
         </div>
         {hasOnSubmit && (
           <DialogFooter>

--- a/web/src/providers/DrawPanelProvider.tsx
+++ b/web/src/providers/DrawPanelProvider.tsx
@@ -273,6 +273,7 @@ export default function DrawPanelProvider({ children }: { children: React.ReactN
       {children}
       <ParamPicker
         value={additionalParams}
+        setAdditionalParams={setAdditionalParams}
         onChange={(newValue) => {
           setAdditionalParams(newValue)
           // TODO: right now this is assuming we olways only have one other parameter aside from the defaultParams


### PR DESCRIPTION
if there's at least 1 number or text input, there will be a confirm button on the bottom.

looks like this:

<img width="585" alt="Screenshot 2023-11-10 at 19 25 14" src="https://github.com/pixelaw/game/assets/38816784/23447924-6792-4b30-87b5-c46943915cf8">
